### PR TITLE
Flexible Identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,20 @@ using the correct stat names as per the [Citrix documentation](https://developer
 </tr>
 
 <tr>
+<td>ServiceGroup</td>
+<td>
+
+<table>
+    <tr><td><strong>Metric</strong></td><td><strong>Description</strong></td>
+    <tr><td>state</td><td>Initial state of the service group. Possible values: 
+    - Disabled: 0
+    - Enabled: 1</td></tr>
+</table>
+  
+</td>
+</tr>
+
+<tr>
 <td>System</td>
 <td>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>netscaler-monitoring-extension</groupId>
     <artifactId>netscaler-monitoring-extension</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.3-ServiceGroupFix</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/com/appdynamics/extensions/netscaler/input/Stat.java
+++ b/src/main/java/com/appdynamics/extensions/netscaler/input/Stat.java
@@ -23,6 +23,8 @@ public class Stat {
     private String alias;
     @XmlAttribute(name = "rootElement")
     private String rootElement;
+    @XmlAttribute(name = "elementIdentifier")
+    private String elementIdentifier;
     @XmlAttribute(name = "metric-type")
     private String metricType;
     @XmlAttribute
@@ -39,6 +41,14 @@ public class Stat {
 
     public void setRootElement(String rootElement) {
         this.rootElement = rootElement;
+    }
+
+    public String getElementIdentifier() {
+        return elementIdentifier;
+    }
+
+    public void setElementIdentifier(String elementIdentifier) {
+        this.elementIdentifier = elementIdentifier;
     }
 
     public String getAlias() {

--- a/src/main/java/com/appdynamics/extensions/netscaler/metrics/MetricDataParser.java
+++ b/src/main/java/com/appdynamics/extensions/netscaler/metrics/MetricDataParser.java
@@ -67,7 +67,8 @@ class MetricDataParser {
             metricValue = currentNode.findValue(metricConfig.getAttr()).asText();
             if (metricValue != null) {
                 String prefix = StringUtils.trim(stat.getAlias(), "|");
-                String name = (currentNode.has("name")) ? currentNode.get("name").asText() + "|" : "";
+                String elementIdentifier = stat.getElementIdentifier() != null? stat.getElementIdentifier() : "name";
+                String name = (currentNode.has(elementIdentifier)) ? currentNode.get(elementIdentifier).asText() + "|" : "";
                 Map<String, String> propertiesMap = oMapper.convertValue(metricConfig, Map.class);
                 metric = new Metric(metricConfig.getAlias(), String.valueOf(metricValue),
                         metricPrefix + "|" + serverName + "|" + prefix + "|" + name

--- a/src/main/resources/conf/metrics.xml
+++ b/src/main/resources/conf/metrics.xml
@@ -49,4 +49,12 @@
             <convert str="TROFS_DOWN" value="5"/>
         </metric>
     </stat>
+
+    <stat url="/nitro/v1/stat/servicegroup" rootElement="servicegroup" elementIdentifier="servicegroupname" alias="Service Group Metrics">
+        <naming use-entry-name="true"/>
+        <metric attr="state" alias="State" aggregation-type="AVERAGE" timeRollupType="AVERAGE" clusterRollupType="INDIVIDUAL">
+            <convert str="DISABLED" value="0"/>
+            <convert str="ENABLED" value="1"/>
+        </metric>
+    </stat>
 </stats>

--- a/src/test/java/com/appdynamics/extensions/netscaler/metrics/MetricDataParserTest.java
+++ b/src/test/java/com/appdynamics/extensions/netscaler/metrics/MetricDataParserTest.java
@@ -86,6 +86,23 @@ public class MetricDataParserTest {
         }
     }
 
+    @Test
+    public void parseNodeDataTest_ServiceGroupMetrics() throws Exception {
+        monitorConfiguration.setMetricXml("src/test/resources/conf/servicegroup-metrics.xml", Stat.Stats.class);
+        Stat.Stats metricConfiguration = (Stat.Stats) monitorConfiguration.getMetricsXml();
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode node = mapper.readValue(new FileInputStream("src/test/resources/json/servicegroup.json"), JsonNode.class);
+        Stat stat = metricConfiguration.getStats()[0];
+        Map<String, String> expectedServiceGroupMetrics = getExpectedServiceGroupMetrics();
+        MetricDataParser metricDataParser = new MetricDataParser(monitorConfiguration.getMetricPrefix());
+        List<Metric> result = metricDataParser.parseNodeData(stat, node, new ObjectMapper(), "NetScaler Instance 1");
+        Assert.assertTrue(result.size() == expectedServiceGroupMetrics.size());
+        for (Metric metric : result) {
+            Assert.assertTrue(expectedServiceGroupMetrics.containsKey(metric.getMetricPath()));
+            Assert.assertTrue(expectedServiceGroupMetrics.get(metric.getMetricPath())
+                    .equals(metric.getMetricValue()));
+        }
+    }
 
     private Map<String, String> getExpectedSystemMetrics() {
         Map<String, String> expectedSystemMetrics = Maps.newHashMap();
@@ -134,6 +151,14 @@ public class MetricDataParserTest {
         expectedServiceMetrics.put(monitorConfiguration.getMetricPrefix() + "|NetScaler Instance 1|Service Metrics|Service 2|Client Connections", "20");
         expectedServiceMetrics.put(monitorConfiguration.getMetricPrefix() + "|NetScaler Instance 1|Service Metrics|Service 2|Active Transactions", "20");
         expectedServiceMetrics.put(monitorConfiguration.getMetricPrefix() + "|NetScaler Instance 1|Service Metrics|Service 2|State", "UNKNOWN");
+        return expectedServiceMetrics;
+    }
+
+    private Map<String, String> getExpectedServiceGroupMetrics() {
+        Map<String, String> expectedServiceMetrics = Maps.newHashMap();
+        expectedServiceMetrics.put(monitorConfiguration.getMetricPrefix() + "|NetScaler Instance 1|Service Group Metrics|eCBF_SSL_4443|State", "ENABLED");
+        expectedServiceMetrics.put(monitorConfiguration.getMetricPrefix() + "|NetScaler Instance 1|Service Group Metrics|Yes_Pulse_UAT_SVCGRP|State", "ENABLED");
+        expectedServiceMetrics.put(monitorConfiguration.getMetricPrefix() + "|NetScaler Instance 1|Service Group Metrics|YesRapidoUAT-SVCGRP|State", "ENABLED");
         return expectedServiceMetrics;
     }
 }

--- a/src/test/resources/conf/servicegroup-metrics.xml
+++ b/src/test/resources/conf/servicegroup-metrics.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ Copyright 2012 AppDynamics LLC and its affiliates.
+  ~ All Rights Reserved.
+  ~ This is unpublished proprietary source code of AppDynamics LLC and its affiliates.
+  ~ The copyright notice above does not evidence any actual or intended publication of such source code.
+  ~
+  -->
+<stats>
+    <stat url="/nitro/v1/stat/servicegroup" rootElement="servicegroup" elementIdentifier="servicegroupname" alias="Service Group Metrics">
+        <naming use-entry-name="true"/>
+        <metric attr="state" alias="State" aggregation-type="AVERAGE" timeRollupType="AVERAGE" clusterRollupType="INDIVIDUAL">
+            <convert str="DISABLED" value="0"/>
+            <convert str="ENABLED" value="1"/>
+        </metric>
+    </stat>
+</stats>

--- a/src/test/resources/json/servicegroup.json
+++ b/src/test/resources/json/servicegroup.json
@@ -1,0 +1,22 @@
+{
+  "errorcode": 0,
+  "message": "Done",
+  "severity": "NONE",
+  "servicegroup": [
+    {
+      "servicegroupname": "eCBF_SSL_4443",
+      "state": "ENABLED",
+      "servicetype": "SSL"
+    },
+    {
+      "servicegroupname": "Yes_Pulse_UAT_SVCGRP",
+      "state": "ENABLED",
+      "servicetype": "SSL"
+    },
+    {
+      "servicegroupname": "YesRapidoUAT-SVCGRP",
+      "state": "ENABLED",
+      "servicetype": "SSL"
+    }
+  ]
+}


### PR DESCRIPTION
Added a feature to define a flexible identifier.

At the moment the netscaler extension is expecting, that each resource hast the property "name" - and that this property can be used as an identifier. 

In case of ServiceGroups, this is not working. The identifier is the "servicegroupname".
https://developer-docs.citrix.com/projects/netscaler-nitro-api/en/12.0/statistics/basic/servicegroup/#properties

Code has been adapted. 
The **stats** element in the `metrics.xml` has now an attribute **elementIdentifier**. This can be used for this purpose. Default is still **name** to not change current behaviour. 